### PR TITLE
feat(content, background): 絵文字の再提案やニュアンスの追加指定機能の実装

### DIFF
--- a/background/messages/emoji-suggest.ts
+++ b/background/messages/emoji-suggest.ts
@@ -4,9 +4,15 @@ import type { EmojiSuggestReq, EmojiSuggestRes } from "~types";
 const handler: PlasmoMessaging.MessageHandler<
   EmojiSuggestReq,
   EmojiSuggestRes
-> = async (req, res) => {
-  // LLM に投げる入力文を 300 文字に制限
+> = async (req, res) => { 
+  /**
+   * API リクエストを整形
+   * 
+   * - text   : LLM に絵文字に変換してもらう文章（必須）を 300 文字に制限
+   * - nuances: 変換してもらいたい絵文字ニュアンスが存在し配列かどうか確認
+   */
   const text = String(req.body.text ?? "").trim().slice(0, 300);
+  const nuances = Array.isArray(req.body?.nuances) ? req.body.nuances : undefined;
 
   if (!text) {
     res.send({ emojiList: [] });
@@ -23,6 +29,7 @@ const handler: PlasmoMessaging.MessageHandler<
         },
         body: JSON.stringify({
           text: text,
+          nuances: nuances, 
         })
       },
     );

--- a/content.tsx
+++ b/content.tsx
@@ -39,7 +39,6 @@ const SkeletonEmojiItem = () => (
       p-3
       flex items-center 
       gap-x-[10px]
-      border-b-2 border-sky-50
     "
   >
     {/* 絵文字部分 */}
@@ -86,7 +85,7 @@ const OverlayArea = () => {
   const [pos, setPos] = useState<Pos | null>(null);         // OverlayArea の表示座標
   const [text, setText] = useState("");
   const [emojiList, setEmojiList] = useState<Emoji[]>([])
-  const [isLoading, setIsLoading] = useState(false);            // 絵文字の suggestion 中かどうか
+  const [isLoading, setIsLoading] = useState(false);        // 絵文字の suggestion 中かどうか
 
   // open フラグや pos の状態により動的に変わる OverlayArea の style 
   const styleDynamic = useMemo<React.CSSProperties>(() => {
@@ -192,6 +191,8 @@ const OverlayArea = () => {
             ml-[100px] 
             pb-2
           "
+          onContextMenu={(e) => e.preventDefault()}
+          onDragStart={(e) => e.preventDefault()}
         />
         {/* 
           テキストボックス
@@ -211,7 +212,7 @@ const OverlayArea = () => {
           */}
           <div 
             className="
-              px-2 pt-1
+              px-3 pt-2
               text-base
               overflow-hidden
             "
@@ -236,6 +237,8 @@ const OverlayArea = () => {
                 rounded-full
                 duration-300 ease-in-out
                 text-center font-bold
+                focus:outline-2 outline-white
+                focus:outline-offset-2 
                 flex flex-row 
                 justify-center items-center
                 gap-x-1 
@@ -243,11 +246,13 @@ const OverlayArea = () => {
                   ? `
                       disabled 
                       bg-gray-200 text-white
+                      focus:outline-gray-200
                       cursor-not-allowed
                     ` 
                   : `
                       bg-sky-50 hover:bg-sky-100
-                      text-sky-500
+                      text-sky-500 hover:text-sky-600
+                      focus:outline-sky-500
                       cursor-pointer
                     `
                 }
@@ -256,7 +261,9 @@ const OverlayArea = () => {
               <RotateCw 
                 size={16}
               />
-              再生成する
+              <div className="translate-y-[-1px]">
+                再生成する
+              </div>
             </button>
           </div>
         </div>
@@ -265,10 +272,13 @@ const OverlayArea = () => {
           src={arrowDown}
           width={20}
           className="mx-auto"
+          onContextMenu={(e) => e.preventDefault()}
+          onDragStart={(e) => e.preventDefault()}
         />
         {/* 提案絵文字リスト */}
         <div 
           className="
+            p-2
             bg-white
             rounded-3xl
             overflow-hidden
@@ -292,11 +302,14 @@ const OverlayArea = () => {
               className="
                 w-full h-20
                 p-3
+                rounded-3xl
+                focus:outline-2 outline-white
+                focus:outline-offset-2 
                 flex items-center 
                 gap-x-[10px]
-                border-b-2 border-sky-50
                 transition-all duration-300 ease-in-out
-                hover:bg-gray-50 hover:text-sky-500
+                hover:bg-sky-50 hover:text-sky-700
+                focus:outline-sky-500 
               "
             >
               <div 

--- a/content.tsx
+++ b/content.tsx
@@ -1,6 +1,7 @@
 import styleLocal from "data-text:./style.css"
 import logoIcon from "data-base64:~assets/logo.svg";
 import arrowDown from "data-base64:~assets/arrow-down.svg";
+import { RotateCw } from 'lucide-react';
 import type { PlasmoGetStyle } from "plasmo"
 import { useState, useMemo, useEffect, useRef } from "react";
 import type { Pos, Emoji, EmojiSuggestReq, EmojiSuggestRes } from "~types";
@@ -85,7 +86,7 @@ const OverlayArea = () => {
   const [pos, setPos] = useState<Pos | null>(null);         // OverlayArea の表示座標
   const [text, setText] = useState("");
   const [emojiList, setEmojiList] = useState<Emoji[]>([])
-  const [loading, setLoading] = useState(false);            // 絵文字の suggestion 中かどうか
+  const [isLoading, setIsLoading] = useState(false);            // 絵文字の suggestion 中かどうか
 
   // open フラグや pos の状態により動的に変わる OverlayArea の style 
   const styleDynamic = useMemo<React.CSSProperties>(() => {
@@ -101,7 +102,7 @@ const OverlayArea = () => {
   }, [open, pos]);
 
   const runSuggest = async (inputText: string) => {
-    setLoading(true);
+    setIsLoading(true);
     setEmojiList([]);
 
     try {
@@ -112,7 +113,7 @@ const OverlayArea = () => {
 
       setEmojiList(res.emojiList ?? []);
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   }
 
@@ -193,18 +194,24 @@ const OverlayArea = () => {
           "
         />
         {/* 
-          選択文字列
-          NOTE: 2 行でトランケート
+          テキストボックス
         */}
         <div 
           className="
             bg-white
-            p-3
-            rounded-2xl
+            p-2
+            rounded-3xl
+            flex flex-col
+            gap-y-3
           "
         >
+          {/* 
+            選択文字列
+            NOTE: 2 行でトランケート
+          */}
           <div 
             className="
+              px-2 pt-1
               text-base
               overflow-hidden
             "
@@ -215,6 +222,42 @@ const OverlayArea = () => {
             }} 
           >
             {text}
+          </div>
+          <div
+            className="
+              flex 
+              justify-end
+            "
+          >
+            <button
+              onClick={() => {runSuggest(text)}}
+              className={`
+                px-4 py-2
+                rounded-full
+                duration-300 ease-in-out
+                text-center font-bold
+                flex flex-row 
+                justify-center items-center
+                gap-x-1 
+                ${isLoading 
+                  ? `
+                      disabled 
+                      bg-gray-200 text-white
+                      cursor-not-allowed
+                    ` 
+                  : `
+                      bg-sky-50 hover:bg-sky-100
+                      text-sky-500
+                      cursor-pointer
+                    `
+                }
+              `}
+            >
+              <RotateCw 
+                size={16}
+              />
+              再生成する
+            </button>
           </div>
         </div>
         {/* ↓ */}
@@ -231,7 +274,7 @@ const OverlayArea = () => {
             overflow-hidden
           "
         >
-          {loading ? (
+          {isLoading ? (
             <div>
               {Array.from({ length: 3 }).map((_, i) => (
                 <SkeletonEmojiItem key={i} />

--- a/content.tsx
+++ b/content.tsx
@@ -243,7 +243,7 @@ const OverlayArea = () => {
                 onClick={() => setIsNuanceOpen(v => !v)}
                 aria-expanded={isNuanceOpen}
                 className={`
-                  w-[42px] h-[40px] py-2
+                  px-4 h-[40px] py-2
                   rounded-full
                   duration-300 ease-in-out
                   text-center font-bold
@@ -276,6 +276,9 @@ const OverlayArea = () => {
                     }  
                   `}
                 />
+                <div className="translate-y-[-1px]">
+                  調整
+                </div>
               </button>
               {/* 選択中のニュアンスがあれば付くバッジ */}
               <span

--- a/content.tsx
+++ b/content.tsx
@@ -1,10 +1,11 @@
 import styleLocal from "data-text:./style.css"
 import logoIcon from "data-base64:~assets/logo.svg";
 import arrowDown from "data-base64:~assets/arrow-down.svg";
-import { RotateCw } from 'lucide-react';
+import { Plus, RotateCw, Check } from 'lucide-react';
 import type { PlasmoGetStyle } from "plasmo"
 import { useState, useMemo, useEffect, useRef } from "react";
-import type { Pos, Emoji, EmojiSuggestReq, EmojiSuggestRes } from "~types";
+import type { Pos, Nuance, Emoji, EmojiSuggestReq, EmojiSuggestRes } from "~types";
+import { NUANCES } from "~types"; 
 import { sendToBackground } from "@plasmohq/messaging";
 
 // 外部 CSS ファイルの内容に style.css の内容を動的に追加
@@ -86,6 +87,8 @@ const OverlayArea = () => {
   const [text, setText] = useState("");
   const [emojiList, setEmojiList] = useState<Emoji[]>([])
   const [isLoading, setIsLoading] = useState(false);        // 絵文字の suggestion 中かどうか
+  const [isNuanceOpen, setIsNuanceOpen] = useState(false); 
+  const [selectedNuances, setSelectedNuances] = useState<Set<Nuance>>(new Set());
 
   // open フラグや pos の状態により動的に変わる OverlayArea の style 
   const styleDynamic = useMemo<React.CSSProperties>(() => {
@@ -100,14 +103,19 @@ const OverlayArea = () => {
     };
   }, [open, pos]);
 
-  const runSuggest = async (inputText: string) => {
+  const runSuggest = async (inputText: string, inputNuances?: Set<Nuance>) => {
     setIsLoading(true);
     setEmojiList([]);
 
     try {
+      const nuances =
+        inputNuances && inputNuances.size > 0
+          ? Array.from(inputNuances)
+          : undefined;
+
       const res = await sendToBackground<EmojiSuggestReq, EmojiSuggestRes>({
         name: "emoji-suggest",
-        body: { text: inputText },
+        body: { text: inputText, nuances },
       });
 
       setEmojiList(res.emojiList ?? []);
@@ -226,12 +234,65 @@ const OverlayArea = () => {
           </div>
           <div
             className="
-              flex 
+              flex gap-x-2
               justify-end
             "
           >
+            <div className="relative">
+              <button
+                onClick={() => setIsNuanceOpen(v => !v)}
+                aria-expanded={isNuanceOpen}
+                className={`
+                  w-[42px] h-[40px] py-2
+                  rounded-full
+                  duration-300 ease-in-out
+                  text-center font-bold
+                  focus:outline-2 outline-white
+                  focus:outline-offset-2 
+                  flex flex-row 
+                  justify-center items-center
+                  gap-x-1 
+                  ${isNuanceOpen
+                    ? `
+                        text-white hover:text-white
+                        bg-sky-500 hover:bg-sky-400 
+                      `
+                    : `
+                        bg-sky-50 hover:bg-sky-100
+                        text-sky-500 hover:text-sky-600
+                        focus:outline-sky-500
+                        cursor-pointer
+                      `
+                  }
+                `}
+              >
+                <Plus
+                  size={16}
+                  className={`
+                    duration-300 ease-in-out
+                    ${isNuanceOpen
+                      ? 'rotate-45'
+                      : ''
+                    }  
+                  `}
+                />
+              </button>
+              {/* 選択中のニュアンスがあれば付くバッジ */}
+              <span
+                className={`
+                  absolute 
+                  top-0 right-0 translate-x-1/4 -translate-y-1/4
+                  duration-300 ease-in-out
+                  w-[10px] h-[10px] rounded-full
+                  ${selectedNuances.size > 0
+                    ? 'bg-sky-500 ring-4 ring-white'
+                    : ''
+                  }
+                `}
+              />
+            </div>
             <button
-              onClick={() => {runSuggest(text)}}
+              onClick={() => {runSuggest(text, selectedNuances)}}
               className={`
                 px-4 py-2
                 rounded-full
@@ -265,6 +326,81 @@ const OverlayArea = () => {
                 再生成する
               </div>
             </button>
+          </div>
+          <div
+            className={`
+              overflow-hidden
+              transition-all duration-300 ease-in-out
+              ${
+                isNuanceOpen 
+                  ? 'max-h-[160px] opacity-100 mt-[-4px]' 
+                  : 'max-h-0 opacity-0 pointer-events-none mt-[-12px]'
+              }
+            `}
+          >
+            <div
+              className="
+                p-4
+                rounded-3xl
+                bg-sky-50
+                flex flex-wrap gap-2
+              "
+            >
+              {NUANCES.map((nuance) => (
+                <div className="relative">
+                  <button
+                    key={nuance}
+                    onClick={() => {
+                      if (isLoading) return;
+                      setSelectedNuances(prev => {
+                        const next = new Set(prev);
+                        if (next.has(nuance)) next.delete(nuance);
+                        else next.add(nuance);
+                        return next;
+                      });
+                    }}
+                    className={`
+                      px-4 py-2
+                      rounded-full
+                      duration-300 ease-in-out
+                      text-xs
+                      text-center font-bold
+                      bg-white
+                      border-2 
+                      focus:outline-2 outline-white
+                      focus:outline-offset-2 focus:outline-sky-500
+                      ${isLoading
+                        ? 'cursor-not-allowed'
+                        : 'hover:text-sky-500'
+                      }
+                      ${selectedNuances.has(nuance)
+                        ? 'text-sky-500 border-sky-500'
+                        : 'text-gray-600  border-white'
+                      }
+                    `}
+                  >
+                    {nuance}
+                  </button>
+                  <span
+                    className={`
+                      absolute 
+                      top-0 left-0 -translate-x-1/4 -translate-y-1/4
+                      duration-300 ease-in-out
+                      w-5 h-5 rounded-full
+                      flex items-center justify-center
+                      ${selectedNuances.has(nuance)
+                        ? 'bg-sky-500 text-white'
+                        : 'text-transparent'
+                      }
+                    `}
+                  >
+                    <Check
+                      size={12}
+                    />
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
         {/* ↓ */}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "5.3.3"
   },
   "manifest": {
-    "version": "1.0.1",
+    "version": "1.1.0",
     "permissions": [
       "activeTab"
     ]

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fontsource/noto-sans-jp": "^5.2.8",
     "@plasmohq/messaging": "^0.7.2",
+    "lucide-react": "^0.562.0",
     "plasmo": "0.90.5",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@plasmohq/messaging':
         specifier: ^0.7.2
         version: 0.7.2(react@18.2.0)
+      lucide-react:
+        specifier: ^0.562.0
+        version: 0.562.0(react@18.2.0)
       plasmo:
         specifier: 0.90.5
         version: 0.90.5(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/node@20.11.5)(postcss@8.5.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2453,6 +2456,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@0.562.0:
+    resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5764,6 +5772,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@0.562.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   magic-string@0.30.21:
     dependencies:

--- a/style.css
+++ b/style.css
@@ -1,3 +1,6 @@
+@import "@fontsource/noto-sans-jp/400.css";
+@import "@fontsource/noto-sans-jp/700.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,9 @@
 export default {
   content: [
     "./**/*.{ts,tsx}",
-    "./build/**/*.html"
+    "./build/**/*.html",
+    "!./node_modules/**",
+    "!./.plasmo/**",
   ],
   theme: {
     extend: {

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,21 @@
 // 座標
 export type Pos = { x: number, y: number };
 
+// 再生成で追加できる絵文字のニュアンス
+// TODO: 将来的にはユーザーが好きな単語を自由に設定できるようにしたい
+export const NUANCES = [
+  "ポジティブ",
+  "人", 
+  "顔", 
+  "動物",
+  "ネガティブ", 
+  "場所", 
+  "道具",
+  "記号", 
+] as const;
+
+export type Nuance = typeof NUANCES[number];
+
 // 絵文字
 export type Emoji = {
   body: string,         // 絵文字本体（例: '🌸'）
@@ -9,5 +24,5 @@ export type Emoji = {
 };
 
 // Plasmo Messaging API のリクエスト / レスポンス形式
-export type EmojiSuggestReq = { text: string };
+export type EmojiSuggestReq = { text: string, nuances?: Nuance[] };
 export type EmojiSuggestRes = { emojiList: Emoji[] };


### PR DESCRIPTION
<!-- 
# 関連する issue を書く
```
close #15
```
- 関連する issue 番号（例: #15）を close の後ろに書くと、PR が close したタイミングで自動で issue も close します
- ref: https://qiita.com/e8750520/items/c9372f88d197acf5ab6d
-->

close #3


### 概要

<!--  
# 概要を書く
- PR の目的と概要がひと目でわかるよう、簡潔に（できれば 1 行で）要約しましょう
-->

期待どおりの絵文字が推薦されなかったときに、同じ文字列を使って再度 LLM に推論させることが容易にできるように、「再生成する」ボタンを設置しました。また、その際に微妙なニュアンスを一緒に指示できるようにしました。

### 変更内容

<!--  
# 変更内容を書き出す
- 具体的な変更内容を箇条書きで書き出しましょう
- 暗黙の了解を信用せず、漏れのないように書いていきます
-->

- 同一の選択中テキストを使って絵文字を再生成するボタンを設置
- 再生成の際にニュアンスを調整する機能を追加

### スクリーンショット

<img width="1490" height="957" alt="image" src="https://github.com/user-attachments/assets/f19c43de-c605-417e-a975-d3f20e0c14a4" />


### 備考

<!--  
# 何か気になることがあれば書いておきましょう
- 実装上うまくいかなかったこと・気がかりなことなどがあれば、残しておきましょう
-->

- 調整の精度（指定したニュアンスどおりに LLM が絵文字を推薦してくれるかどうか）は要確認 & 要調整